### PR TITLE
Finishing TriggerAccident(int accident = -1), Ready for review

### DIFF
--- a/Assets/Scripts/Blocks/Block.cs
+++ b/Assets/Scripts/Blocks/Block.cs
@@ -104,7 +104,7 @@ public class Block : MonoBehaviour {
 
     public void LoadBlock()
     {
-        GameManager.instance.systemManager.AllBlockLinks.Add(this);
+        GameManager.instance.systemManager.AllBlocks.Add(this);
         if (scheme.consumption > 0)
         {
             GameManager.instance.systemManager.AllBlocksRequiringPower.Add(this);

--- a/Assets/Scripts/System/CityManager.cs
+++ b/Assets/Scripts/System/CityManager.cs
@@ -85,39 +85,28 @@ public class CityManager : MonoBehaviour {
         return attraction;
     }
     
-    public void TriggerAccident(int accident = -1)
+    public void TriggerAccident(BlockState accident)
     {
         if(GameManager.instance.systemManager.AllBlocks.Count == 0) return;
 
-        if(accident == -1) 
-        {
-            accident = (int)accidentStates[Random.Range(0, accidentStates.Length)];
-        }
-        else if(accident > System.Enum.GetNames(typeof(BlockState)).Length || accident < -1)
-        {
-            Debug.Log("You entered a wrong accident parameter");
-            return;
-        }
-        
-        if( IsConsideredAccident( (BlockState)accident) )
+        if( IsConsideredAccident( accident ) )
         {
             int rand = Random.Range(0, GameManager.instance.systemManager.AllBlocks.Count);
             int blockMet = 0;
-            while( GameManager.instance.systemManager.AllBlocks[rand].states.Contains( (BlockState)accident ))
+            while( GameManager.instance.systemManager.AllBlocks[rand].states.Contains( accident ))
             {
                 if(blockMet++ > GameManager.instance.systemManager.AllBlocks.Count) 
                 {
-                    Debug.Log("AllBlock are in bad condition already");
+                    Logger.Debug("All blocks already have " + accident + " as a state");
                     return;
                 }
-
                 rand = Random.Range(0, GameManager.instance.systemManager.AllBlocks.Count);
             }
-            GameManager.instance.systemManager.AllBlocks[rand].AddState( (BlockState)accident );
+            GameManager.instance.systemManager.AllBlocks[rand].AddState( accident );
         }
         else
         {
-            Debug.Log("This state is not considered as a accident");
+            Debug.Log( accident + " is not considered as a accident" );
         }
     }
 

--- a/Assets/Scripts/System/CityManager.cs
+++ b/Assets/Scripts/System/CityManager.cs
@@ -93,8 +93,9 @@ public class CityManager : MonoBehaviour {
         {
             accident = (int)accidentStates[Random.Range(0, accidentStates.Length)];
         }
-        else if(accident > System.Enum.GetNames(typeof(BlockState)).Length)
+        else if(accident > System.Enum.GetNames(typeof(BlockState)).Length || accident < -1)
         {
+            Debug.Log("You entered a wrong accident parameter");
             return;
         }
         

--- a/Assets/Scripts/System/CityManager.cs
+++ b/Assets/Scripts/System/CityManager.cs
@@ -104,10 +104,7 @@ public class CityManager : MonoBehaviour {
             }
             GameManager.instance.systemManager.AllBlocks[rand].AddState( accident );
         }
-        else
-        {
-            Debug.Log( accident + " is not considered as a accident" );
-        }
+        else Logger.Debug( accident + " is not considered as a accident" );
     }
 
     bool IsConsideredAccident(BlockState state)

--- a/Assets/Scripts/System/CityManager.cs
+++ b/Assets/Scripts/System/CityManager.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class CityManager : MonoBehaviour {
 
     public string cityName = "Valenciennes";
+    public BlockState[] accidentStates = { BlockState.OnFire, BlockState.OnRiot, BlockState.Damaged };
+
 
     //Assign the best house found to a citizen
     public void AutoHouseCitizen(PopulationManager.Citizen citizen)
@@ -82,15 +84,51 @@ public class CityManager : MonoBehaviour {
         attraction -= house.distanceToGround * 0.2f;
         return attraction;
     }
-
+    
     public void TriggerAccident(int accident = -1)
     {
-        if(accident == -1) accident = Random.Range(0, System.Enum.GetValues(typeof(BlockState)).Length);
-        int rand = Random.Range(0, GameManager.instance.systemManager.AllBlocks.Count);
-        while(GameManager.instance.systemManager.AllBlocks[rand].states.Contains((BlockState)accident))
+        if(GameManager.instance.systemManager.AllBlocks.Count == 0) return;
+
+        if(accident == -1) 
         {
-            rand = Random.Range(0, GameManager.instance.systemManager.AllBlocks.Count);
+            accident = (int)accidentStates[Random.Range(0, accidentStates.Length)];
         }
-        GameManager.instance.systemManager.AllBlocks[rand].AddState((BlockState)accident);
+        else if(accident > System.Enum.GetNames(typeof(BlockState)).Length)
+        {
+            return;
+        }
+        
+        if( IsConsideredAccident( (BlockState)accident) )
+        {
+            int rand = Random.Range(0, GameManager.instance.systemManager.AllBlocks.Count);
+            int blockMet = 0;
+            while( GameManager.instance.systemManager.AllBlocks[rand].states.Contains( (BlockState)accident ))
+            {
+                if(blockMet++ > GameManager.instance.systemManager.AllBlocks.Count) 
+                {
+                    Debug.Log("AllBlock are in bad condition already");
+                    return;
+                }
+
+                rand = Random.Range(0, GameManager.instance.systemManager.AllBlocks.Count);
+            }
+            GameManager.instance.systemManager.AllBlocks[rand].AddState( (BlockState)accident );
+        }
+        else
+        {
+            Debug.Log("This state is not considered as a accident");
+        }
+    }
+
+    bool IsConsideredAccident(BlockState state)
+    {
+        foreach(BlockState s in accidentStates)
+        {
+            if(state == s)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Assets/Scripts/System/SystemManager.cs
+++ b/Assets/Scripts/System/SystemManager.cs
@@ -6,7 +6,7 @@ public class SystemManager : MonoBehaviour {
 
     public List<Generator> AllGenerators = new List<Generator>();
     public List<Block> AllBlocksRequiringPower = new List<Block>();
-    public List<Block> AllBlockLinks = new List<Block>();
+    public List<Block> AllBlocks = new List<Block>();
     public List<Occupator> AllOccupators = new List<Occupator>();
     public List<House> AllHouses = new List<House>();
     public List<FoodProvider> AllFoodProviders = new List<FoodProvider>();
@@ -33,7 +33,7 @@ public class SystemManager : MonoBehaviour {
     {
         AllGenerators.RemoveAll(o => o.gameObject == target);
         AllBlocksRequiringPower.RemoveAll(o => o.gameObject == target);
-        AllBlockLinks.RemoveAll(o => o.gameObject == target);
+        AllBlocks.RemoveAll(o => o.gameObject == target);
         AllHouses.RemoveAll(o => o.gameObject == target);
         AllFoodProviders.RemoveAll(o => o.gameObject == target);
         AllSpatioports.RemoveAll(o => o.gameObject == target);
@@ -56,7 +56,7 @@ public class SystemManager : MonoBehaviour {
     //S'execute à chaques fois qu'un cycle passe
     public IEnumerator OnNewCycle()
     {
-        foreach (Block block in AllBlockLinks)
+        foreach (Block block in AllBlocks)
         {
             block.NewCycle();
         }
@@ -114,7 +114,7 @@ public class SystemManager : MonoBehaviour {
     public void UpdateBlocksDisabled()
     {
         Logger.Debug("Disabling blocks out of spatioport range");
-        foreach (Block block in AllBlockLinks)
+        foreach (Block block in AllBlocks)
         {
             if (block.isConsideredDisabled && block.GetComponent<Spatioport>() == null)
             {
@@ -306,7 +306,7 @@ public class SystemManager : MonoBehaviour {
     IEnumerator ResetSpatioportInfluence()
     {
         Logger.Debug("Resetting spatioport influence");
-        foreach (Block block in AllBlockLinks)
+        foreach (Block block in AllBlocks)
         {
             block.isLinkedToSpatioport = false;
             block.isConsideredDisabled = true;


### PR DESCRIPTION
We can now use GameManager.instance.cityManager.TriggerAccident(int accident) to add a accident state(OnFire, OnRiot, Damaged) to a random block of the city.

I added a new array of <BlockState> in the city manager determining all state considered as accident.

Random -> TriggerAccident(0)
OnFire -> TriggerAccident(1)
OnRiot -> TriggerAccident(2)
Damaged -> TriggerAccident(3)

Using TriggerAccident(0) will not add any states because (BlockState)0 which is BlockState.Powered is not considered as a accident state.

Using TriggerAccident(182048) will not do anything cause the system will detect that BlockState.Length is not that high.

Using TriggerAccident(-15) will not do anything cause the system will detect that a state reference must be higher or equal to 0.
