### PR TITLE
System and population notation updates, + some fixes

### DIFF
--- a/Assets/Databank/OLD/House.asset
+++ b/Assets/Databank/OLD/House.asset
@@ -12,15 +12,14 @@ MonoBehaviour:
   m_Name: House
   m_EditorClassIdentifier: 
   link: {fileID: 0}
-  movable: 1
-  destrucible: 1
-  title: House
-  description: A simple house
+  isMovable: 1
+  isDestroyable: 1
+  isStorable: 1
+  isBuyable: 1
+  canBuildAbove: 1
   model: {fileID: 1082695537851358, guid: c068bab240e99114ab3b4b61ab023a7a, type: 2}
-  icon: {fileID: 21300000, guid: a02562d9c883e2a43b53ef0a9ea2ab2e, type: 3}
   ID: 7
-  level: 1
-  complexity: 1
   consumption: 1
+  sensibility: 1
   flags:
-  - House_5_1_1_Scientist
+  - House_5_1_1_scientist

--- a/Assets/Databank/OLD/Observatory.asset
+++ b/Assets/Databank/OLD/Observatory.asset
@@ -12,13 +12,14 @@ MonoBehaviour:
   m_Name: Observatory
   m_EditorClassIdentifier: 
   link: {fileID: 0}
-  title: Observatory
-  description: Occupy 5 scientists
+  isMovable: 1
+  isDestroyable: 1
+  isStorable: 1
+  isBuyable: 1
+  canBuildAbove: 1
   model: {fileID: 1547902619353416, guid: 8c422b2db74c1ca4288c9fcf898e47c5, type: 2}
-  icon: {fileID: 21300000, guid: e971c1619afda2c4fabc73ddd1d52eb6, type: 3}
   ID: 2
-  level: 1
-  complexity: 1
   consumption: 1
+  sensibility: 1
   flags:
-  - Occupator_5_3_Scientist
+  - Occupator_5_3_scientist

--- a/Assets/Databank/OLD/PowerPlant.asset
+++ b/Assets/Databank/OLD/PowerPlant.asset
@@ -17,14 +17,10 @@ MonoBehaviour:
   isStorable: 1
   isBuyable: 1
   canBuildAbove: 1
-  title: PowerPlant
-  description: Produce 5 power.
   model: {fileID: 1755213086024464, guid: 08d12078b1d8575428167403a7e1cda5, type: 2}
-  icon: {fileID: 21300000, guid: 974656c4ea5932d4c842d379b5832819, type: 3}
   ID: 3
-  level: 1
-  complexity: 1
   consumption: 0
+  sensibility: 1
   flags:
   - Generator_5
-  - Occupator_2_3_Scientist
+  - Occupator_2_3_scientist

--- a/Assets/Scripts/Blocks/Block.cs
+++ b/Assets/Scripts/Blocks/Block.cs
@@ -75,6 +75,7 @@ public class Block : MonoBehaviour {
     //Called when block is in range of a spatioport
     public void Enable()
     {
+        AddState(BlockState.Powered);
         //Active toutes les fonctionnalités du bloc
         foreach (Flag flag in activeFlags)
         {
@@ -107,7 +108,6 @@ public class Block : MonoBehaviour {
     public void LoadBlock()
     {
         GameManager.instance.systemManager.AllBlocks.Add(this);
-
         if (scheme.consumption > 0)
         {
             GameManager.instance.systemManager.AllBlocksRequiringPower.Add(this);

--- a/Assets/Scripts/Construction/GridManagement.cs
+++ b/Assets/Scripts/Construction/GridManagement.cs
@@ -235,7 +235,6 @@ public class GridManagement : MonoBehaviour
         GameObject newBlock = CreateBlockFromId(blockId);
         MoveBlock(newBlock, coordinates);
         Logger.Debug("Spawned block : " + newBlock.GetComponent<Block>().scheme.name + " with prefab " + GameManager.instance.library.blockPrefab.name + " at position "+ coordinates.ToString());
-        UpdateGridSystems();
         return newBlock;
     }
 

--- a/Assets/Scripts/Flags/House.cs
+++ b/Assets/Scripts/Flags/House.cs
@@ -57,9 +57,6 @@ public class House : Flag
             //Ecrit sur la carte d'identité du citoyen qu'il habite ici désormais
             citizen.habitation = this;
 
-
-            //Fourni un travail au nouveau citoyen, s'il y en a un de disponible
-            StartCoroutine(GameManager.instance.systemManager.RecalculateJobs());
             return;
         }
     }

--- a/Assets/Scripts/Population/PopulationManager.cs
+++ b/Assets/Scripts/Population/PopulationManager.cs
@@ -180,7 +180,6 @@ public class PopulationManager : MonoBehaviour {
         }
         Logger.Debug("Spawned " + amount + " citizens of type " + type.codeName + " to the citizen list");
         CitizenArrival.Invoke(citizens.Count, type);
-        GameManager.instance.systemManager.OnNewMicrocycle();
         return citizens;
     }
 

--- a/Assets/Scripts/System/CityManager.cs
+++ b/Assets/Scripts/System/CityManager.cs
@@ -15,11 +15,10 @@ public class CityManager : MonoBehaviour {
     [System.Serializable]
     public class HouseNotation
     {
-        public int goodNotationTreshold = 0; //Above this note, house is considered "Good"
-        public int badNotationTreshold = -5; //Under this note, house is considered "Bad"
+        public int goodNotationTreshold = -5; //Above this note, house is considered "Good"
+        public int badNotationTreshold = -10; //Under this note, house is considered "Bad"
         public int wrongPopulationType = -2;
         public int noFood = -3;
-        public int notEnoughFood = -1;
         public int noOccupations = -2;
         public int noPower = -2;
         public int damaged = -2; //NOT TAKEN IN ACCOUNT YETTTTTTTTTTTTTTTTTTT
@@ -38,7 +37,7 @@ public class CityManager : MonoBehaviour {
     //Finds a house for every citizens (Soon it'll take a priority order into account)
     public void HouseEveryone()
     {
-
+        GetBestHouses();
         for (int i = 0; i < GameManager.instance.populationManager.populationTypeList.Length; i++)
         {
             HousePopulation(GameManager.instance.populationManager.populationTypeList[i]);
@@ -59,7 +58,7 @@ public class CityManager : MonoBehaviour {
                 GameManager.instance.populationManager.ChangePopulationMood(pop, topHabitations[pop].First().Value);
 
                 //Si la maison est désormais remplie, on la retire de la liste des habitations pour chaque population
-                if (foundHouse.affectedCitizen.Count < foundHouse.slotAmount)
+                if (foundHouse.affectedCitizen.Count >= foundHouse.slotAmount)
                 {
                     foreach (Population popType in GameManager.instance.populationManager.populationTypeList)
                     {
@@ -108,14 +107,22 @@ public class CityManager : MonoBehaviour {
 
         //If house isn't connected to spatioport, it sucks
         if (!house.block.isLinkedToSpatioport)
+        {
             return GameManager.instance.populationManager.moodModifierIfNoHabitation;
+        }
 
         //If house is already full, it also sucks
         if (house.affectedCitizen.Count >= house.slotAmount)
+        {
             return GameManager.instance.populationManager.moodModifierIfNoHabitation;
+        }
 
 
         bool profileFound = false;
+        bool powered = false;
+        bool foodLeft = false;
+        bool jobLeft = false;
+
         foreach (Population profile in house.acceptedPop)
         {
             if (profile == populationType)
@@ -123,28 +130,27 @@ public class CityManager : MonoBehaviour {
                 profileFound = true;
             }
         }
-        if (!profileFound)
-            notation += houseNotation.wrongPopulationType;
 
-        if (!house.powered)
+        if (house.powered)
         {
-            notation += houseNotation.noFood;
+            powered = true;
         }
 
-        float foodLeft = 0;
+        float foodStock = 0;
         foreach (FoodProvider distributor in house.foodProvidersInRange)
         {
-            foodLeft += distributor.foodLeft;
+            foodStock += distributor.foodLeft;
         }
-        if (foodLeft > 0 && foodLeft <= house.foodConsumptionPerHabitant)
+        if (foodStock > 0 && foodStock >= house.foodConsumptionPerHabitant)
         {
-            notation += houseNotation.notEnoughFood;
-        } else if (foodLeft <= 0)
+            foodLeft = true;
+        } else
         {
-            notation += houseNotation.noFood;
+            foodLeft = false;
         }
 
-        bool jobLeft = false;
+
+
         foreach (Occupator occupator in house.occupatorsInRange)
         {
             foreach (Population pop in occupator.acceptedPopulation)
@@ -154,6 +160,19 @@ public class CityManager : MonoBehaviour {
                     jobLeft = true;
                 }
             }
+        }
+
+        if (!profileFound)
+        {
+            notation += houseNotation.wrongPopulationType;
+        }
+        if (!powered)
+        {
+            notation += houseNotation.noPower;
+        }
+        if (!foodLeft)
+        {
+            notation += houseNotation.noFood;
         }
         if (!jobLeft)
         {

--- a/Assets/Scripts/System/FlagReader.cs
+++ b/Assets/Scripts/System/FlagReader.cs
@@ -182,14 +182,14 @@ public class FlagReader : MonoBehaviour
 					}
 					catch(FormatException fe)
 					{
-						Destroy(newOccupator);
+                        Destroy(newOccupator);
                         Logger.Warn( block.scheme.name + " - Occupator : Unvalid slotAmount entry for as the first parameter. Please enter an int value.");
 						break;
 					}
 
 					if(slotAmount < 0)
 					{
-						Destroy(newOccupator);
+                        Destroy(newOccupator);
                         Logger.Warn( block.scheme.name + " - Occupator : slot value has to be higher than 0.");
 						break;
 					}
@@ -219,7 +219,7 @@ public class FlagReader : MonoBehaviour
 
 					if(result != "")
 					{
-						Destroy(newOccupator);
+                        Destroy(newOccupator);
                         Logger.Warn( block.scheme.name + " - Occupator : " + result);
 						break;
 					}

--- a/Assets/Scripts/System/MissionCallbackManager.cs
+++ b/Assets/Scripts/System/MissionCallbackManager.cs
@@ -84,6 +84,7 @@ public class MissionCallbackManager : MonoBehaviour
             if (GameManager.instance.systemManager != null)
             {
                 GameManager.instance.systemManager.UpdateBlocksRequiringPower();
+                GameManager.instance.systemManager.OnCalculEnd();
             }
         }
         yield return null;
@@ -107,6 +108,7 @@ public class MissionCallbackManager : MonoBehaviour
             if (GameManager.instance.systemManager != null)
             {
                 GameManager.instance.systemManager.UpdateBlocksDisabled();
+                GameManager.instance.systemManager.OnCalculEnd();
             }
         }
         yield return null;

--- a/Assets/Scripts/System/OverlayManager.cs
+++ b/Assets/Scripts/System/OverlayManager.cs
@@ -206,9 +206,8 @@ public class OverlayManager : MonoBehaviour
                     }
 
                     averageNotation = averageNotation / popManager.populationTypeList.Length;
-                    averageNotation += -cityManager.houseNotation.notEnoughFood;
-                    averageNotation += -cityManager.houseNotation.noOccupations;
-                    averageNotation += -cityManager.houseNotation.wrongPopulationType;
+                    averageNotation -= cityManager.houseNotation.noOccupations;
+                    averageNotation -= cityManager.houseNotation.wrongPopulationType;
 
                     if (averageNotation < cityManager.houseNotation.badNotationTreshold)
                     {

--- a/Assets/Scripts/System/Temporality.cs
+++ b/Assets/Scripts/System/Temporality.cs
@@ -65,7 +65,6 @@ public class Temporality : MonoBehaviour {
         {
             cycleProgression = 0f; //On ne reset pas à 0 pour éviter une transition sacadée au niveau de l'aperçu du temps passé
             AddCycle();
-            AddMicroCycle();
             GetMicroDuration();
         }
     }


### PR DESCRIPTION
Updated system (Corrected useless calls), system doesn't launch a cycle AND a microcycle function at the same time anymore, tweaked notation treshold for notation overlay, fixed notation overlay, fixed some flags not generating their scripts, added a "onCalculEnd()" function on the system, getNotation has been cleaned. Population now automatically choose an habitation and a job each microcycle.